### PR TITLE
Make the Redraw button always requery the data

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -78,7 +78,7 @@
             </div>
             <div>
               <!-- this button force-redraws everything. TODO: make it more obvious or move it -->
-              <input type="button" class="btn btn-primary" value="Redraw" />
+              <input type="button" id="requery-data" class="btn btn-primary" value="Redraw" />
             </div>
           </div>
         </div>

--- a/webapp/js/main.js
+++ b/webapp/js/main.js
@@ -214,6 +214,10 @@ $( function() {
       updateStats();
   });
 
+  $('#requery-data').on('click', function(e) {
+    updateStats();
+  });
+
   $('#server-conf-save').on('click', function(e) {
     tempServerName = $('#server-name').val();
 


### PR DESCRIPTION
I can blank out either the from or to date picker (or both) and the API
happily accepts a query with only 1 (or neither) of from and to
parameters. If "to" is not given then the API returns all the available
data from "from". Similar sensible behaviour if "from" is omitted.
But the data was only being re-queried when a date picker field changed.
Actually we want to also re-query when the Redraw button is pressed.
This is particularly needed when the "to" date picker is empty - we can
press Redraw and the data will be brought "up to current" without having
to touch the date picker controls.