### PR TITLE
Return lower and upper as the actual first and last timestamps

### DIFF
--- a/SERVER_README.md
+++ b/SERVER_README.md
@@ -80,8 +80,10 @@ Parameters:
 Response data fields:
 
 - `count`: number of data points returned
-- `lower`: interpreted lower bound
-- `upper`: interpreted upper bound
+- `lower`: lowest actual timestamp in the data (might be greater than from)
+- `upper`: highest actual timestamp in the data (might be less than to)
+- `from`: the requested start date
+- `to`: the requested end date
 - `full_count`: total number of data points available in range
 
 Example response:
@@ -91,7 +93,8 @@ Example response:
     "data": {
         "count": 2,
         "full_count": 2,
-        "lower": 1474357000,
+        "from": 1474357000,
+        "lower": 1474357004,
         "temperature_array": [
             {
                 "temperature": 5.7,
@@ -102,7 +105,8 @@ Example response:
                 "timestamp": 1474357009
             }
         ],
-        "upper": 1474357010
+        "to": 1474357010
+        "upper": 1474357009
     },
     "status": 200,
     "success": true

--- a/app.py
+++ b/app.py
@@ -25,12 +25,12 @@ class temperature_handler(BaseHandler):
     def get(self, timestamp=None):
         """return the temperature by key"""
 
-        lower = self.get_query_argument('from', None)
-        upper = self.get_query_argument('to', None)
+        from_timestamp = self.get_query_argument('from', None)
+        to_timestamp = self.get_query_argument('to', None)
         limit = self.get_query_argument('limit', cfg.temp_max_length)
 
         try:
-            lower, upper = utils.validate_bounds(lower, upper)
+            from_timestamp, to_timestamp = utils.validate_bounds(from_timestamp, to_timestamp)
             limit = min(int(limit), cfg.temp_max_length)
         except:
             return self.send_error(400, reason='invalid from and/or to parameters')
@@ -55,11 +55,13 @@ class temperature_handler(BaseHandler):
 
         # otherwise, use the temperature range
         else:
-            temps, n = self.db.get_temperature_list(lower, upper, limit)
+            temps, n, first_timestamp, last_timestamp = self.db.get_temperature_list(from_timestamp, to_timestamp, limit)
             data = {'count': len(temps),
                     'temperature_array': temps,
-                    'lower': lower,
-                    'upper': upper,
+                    'from': from_timestamp,
+                    'to': to_timestamp,
+                    'lower': first_timestamp,
+                    'upper': last_timestamp,
                     'full_count': n
             }
             return self.send_data(data)
@@ -83,22 +85,22 @@ class stats_temp_handler(BaseHandler):
 
     def get(self, stats_type):
 
-        lower = self.get_query_argument('from', None)
-        upper = self.get_query_argument('to', None)
+        from_timestamp = self.get_query_argument('from', None)
+        to_timestamp = self.get_query_argument('to', None)
 
         try:
-            lower, upper = utils.validate_bounds(lower, upper)
+            from_timestamp, to_timestamp = utils.validate_bounds(from_timestamp, to_timestamp)
         except:
             return self.send_error(400, reason='invalid range (from-to)')
 
         if stats_type == 'min':
-            stats = self.db.get_temperature_min(lower, upper)
+            stats = self.db.get_temperature_min(from_timestamp, to_timestamp)
             if stats: return self.send_data(stats)
         elif stats_type == 'max':
-            stats = self.db.get_temperature_max(lower, upper)
+            stats = self.db.get_temperature_max(from_timestamp, to_timestamp)
             if stats: return self.send_data(stats)
         elif stats_type == 'ave':
-            ave = self.db.get_temperature_avg(lower, upper)
+            ave = self.db.get_temperature_avg(from_timestamp, to_timestamp)
             if ave:
                 return self.send_data(ave)
 

--- a/database.py
+++ b/database.py
@@ -89,9 +89,13 @@ class db():
             jump = (n // limit) + 1
             query = query.filter(Temperature.id % jump == 0)
 
-        # return a list of dictionaries, and number of total rows in that range
+        # return:
+        #   a list of dictionaries,
+        #   number of rows selected in that range
+        #   timestamp of the first record
+        #   timestamp of the last record
         temps = list(map(lambda t: t.dict(), query.all()))
-        return (temps, n)
+        return (temps, n, query.first().timestamp, query.order_by('-timestamp').first().timestamp)
 
     def save_temperature(self, temp, time):
         """ log the temperature in the database """

--- a/database.py
+++ b/database.py
@@ -94,8 +94,9 @@ class db():
         #   number of rows selected in that range
         #   timestamp of the first record
         #   timestamp of the last record
-        temps = list(map(lambda t: t.dict(), query.all()))
-        return (temps, n, query.first().timestamp, query.order_by('-timestamp').first().timestamp)
+        results = query.all()
+        temps = list(map(lambda t: t.dict(), results))
+        return (temps, n, results[0].timestamp, results[-1].timestamp)
 
     def save_temperature(self, temp, time):
         """ log the temperature in the database """


### PR DESCRIPTION
When we ask for some big date-time range in from and to, it is nice to
know the actual date-time range returned, so we can show this to the
user (e.g. in the mouse over box that describes the Temperature graph).
After this change, the lower and upper attributes are returned as the
actual least and greatest time stamps in the returned data set.
"from" and "to" are also returned, in case something cares about them
and wants to confirm exactly what was asked for.
Var names lower and upper changes to from_timestamp and to_timestamp to
(hopefully) reduce potential confusion.