### PR TITLE
Display details of the average

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -111,6 +111,9 @@
             </div>
             <div class="panel-body">
               <p><span class="ave-temperature"></span>°C</p>
+              over <span class="ave-temperature-count"></span> samples<br />
+              from <span class="ave-temperature-date-lower"></span><br />
+              to <span class="ave-temperature-date-upper"></span>
             </div>
           </div>
         </div>

--- a/webapp/js/main.js
+++ b/webapp/js/main.js
@@ -202,7 +202,13 @@ function updateStats() {
   t.getStat('ave', limit.from, limit.to).done(function(res, statustext) {
     if (res.data.count > 0) {
       var temp = res.data.ave;
+      var count = res.data.count;
+      var lower = res.data.lower;
+      var upper = res.data.upper;
       $('.ave-temperature').text(temp.toFixed(2));
+      $('.ave-temperature-count').text(count);
+      $('.ave-temperature-date-lower').text(moment.unix(lower).toLocaleString());
+      $('.ave-temperature-date-upper').text(moment.unix(upper).toLocaleString());
     }
   });
 


### PR DESCRIPTION
Show the user how many samples from and to when were used to calculate
the average.
This makes use of the lower and upper actual ranges that the latest API
will return - see other pull request.