### PR TITLE
Always include the first and last entries

### DIFF
--- a/database.py
+++ b/database.py
@@ -87,7 +87,9 @@ class db():
         if n > limit:
             # if so, skip every jump_th row
             jump = (n // limit) + 1
-            query = query.filter(Temperature.id % jump == 0)
+            first_id = query.first().id
+            last_id = first_id + n - 1
+            query = query.filter(((Temperature.id - first_id) % jump == 0) | (Temperature.id == last_id))
 
         # return:
         #   a list of dictionaries,


### PR DESCRIPTION
When doing a temperature query that would return more than the specified
limit of rows:
1) Find out the id of the first row
2) Calculate the offset from the first row, so that (Temperature.id -
first_id) starts from 0 and thus the very first row is chosen by the
filter, and every "jump" rows after that.
3) Calculate the id of the last row.
4) Explicitly put the last row in the filtered set, so that the very
latest data available that matches the query ends up returned to the
user.

This ensures that the total range of a query is always maximal, even if
some data in the middle has been filtered out to keep the total data
size less than the limit.