### PR TITLE
Handle lower and upper when no matching results

### DIFF
--- a/database.py
+++ b/database.py
@@ -84,7 +84,10 @@ class db():
         #   timestamp of the last record
         results = query.all()
         temps = list(map(lambda t: t.dict(), results))
-        return (temps, n, results[0].timestamp, results[-1].timestamp)
+        return (temps,
+                n,
+                results[0].timestamp if 0 < len(results) else None,
+                results[-1].timestamp if 0 < len(results) else None)
 
     def save_temperature(self, temp, time):
         """ log the temperature in the database """


### PR DESCRIPTION
If a request for a temperature array was done for a time range that had
no data, then the existing code would get an array index error trying to
access results[1] and results[-1]
This fixes the problem.
I also confirmed that a query that has just a single sample in the time
period works OK - results[1] and results[-1] are the same thing, which
is good.