### PR TITLE
Add test mode message to server info

### DIFF
--- a/webapp/js/main.js
+++ b/webapp/js/main.js
@@ -43,7 +43,7 @@ Temperature.prototype.errorFunc = function(res, textstatus, error, title) {
   this.ready = false;
 
   // say so in server info
-  $('.server-info').html('Not connected to any server. Click the Change Server button to configure.');
+  $('.server-info').html('Not connected to any server. Click the <code>Change Server</code> button to configure.');
 };
 
 Temperature.prototype.getInfo = function() {
@@ -234,7 +234,7 @@ function getInitialServerSetup() {
     }
 
     if (!res.data.live) {
-      info += '<br /><strong>Server is in test mode generating random temperature data.</strong>';
+      info += ' <strong>Server is in test mode generating random temperature data.</strong>';
     }
 
     $('.server-info').html(info);

--- a/webapp/js/main.js
+++ b/webapp/js/main.js
@@ -43,7 +43,7 @@ Temperature.prototype.errorFunc = function(res, textstatus, error, title) {
   this.ready = false;
 
   // say so in server info
-  $('.server-info').html('Not connected to any server. Click the button below to configure.');
+  $('.server-info').html('Not connected to any server. Click the Change Server button to configure.');
 };
 
 Temperature.prototype.getInfo = function() {
@@ -231,6 +231,10 @@ function getInitialServerSetup() {
 
     if (res.data.location) {
       info += ' Location: <i>' + res.data.location + '</i>';
+    }
+
+    if (!res.data.live) {
+      info += '<br /><strong>Server is in test mode generating random temperature data.</strong>';
     }
 
     $('.server-info').html(info);


### PR DESCRIPTION
So that the web app user will be informed when the server is in random
temperature generating mode.
It should be fine to say nothing when in proper live mode - the normal
end-user should assume it is real unless told otherwise.