### PR TITLE
Allow selection of different units for temperature

### DIFF
--- a/SERVER_README.md
+++ b/SERVER_README.md
@@ -43,15 +43,22 @@ or on error:
 
 ### GET /api/temperature/current
 
-Returns the current temperature (ie. last recorded temperature in database).
+Returns the current temperature (ie. last recorded temperature in database) and its unit of measure.
+
+Parameters:
+
+- `unit` - C, F or K return the result in Celsius, Farenheit or Kelvin (default: C)
 
 Example response:
 
 ```json
 {
     "data": {
-        "temperature": 36.3,
-        "timestamp": 1474264875
+        "unit": "C",
+        "current": {
+            "temperature": 36.3,
+            "timestamp": 1474264875
+        },
     },
     "status": 200,
     "success": true
@@ -61,9 +68,27 @@ Example response:
 
 ### GET /api/temperature/:timestamp
 
-Returns the temperature at `timestamp` if available, otherwise temperature for closest available time.
+Returns the spot temperature at `timestamp` if available, otherwise temperature for closest available time, and its unit of measure.
 
-Response follows the same schema as for the current temperature endpoint.
+Parameters:
+
+- `unit` - C, F or K return the result in Celsius, Farenheit or Kelvin (default: C)
+
+Example response:
+
+```json
+{
+    "data": {
+        "unit": "C",
+        "spot": {
+            "temperature": 36.3,
+            "timestamp": 1474264875
+        },
+    },
+    "status": 200,
+    "success": true
+}
+```
 
 
 ### GET /api/temperature/
@@ -74,12 +99,14 @@ Parameters:
 
 - `from` - [timestamp] start date of temperature range (default: 0)
 - `to` - [timestamp] end date of temperature range (default: current time)
+- `unit` - C, F or K return the result in Celsius, Farenheit or Kelvin (default: C)
 - `limit` - [integer] limit the number of temperature entries returned (default: `temp_max_length` as configured in
   config.py). Note: a limit parameter higher than set in server config will be ignored.
 
 Response data fields:
 
 - `count`: number of data points returned
+- `unit`: the unit of measure C, F or K
 - `lower`: lowest actual timestamp in the data (might be greater than from)
 - `upper`: highest actual timestamp in the data (might be less than to)
 - `from`: the requested start date
@@ -93,6 +120,7 @@ Example response:
     "data": {
         "count": 2,
         "full_count": 2,
+        "unit": "C",
         "from": 1474357000,
         "lower": 1474357004,
         "temperature_array": [
@@ -122,7 +150,7 @@ Parameters as for getting an array of temperatures.
 
 Response data fields:
 
-- `count`, `lower`, `upper`, `from`, `to` as above
+- `count`, `lower`, `upper`, `from`, `to`, `unit` as above
 - `ave`: average temperature as a float number
 - `max`: maximum temperature as a temperature dictionary with `temperature` and `timestamp` fields
 - `min`: as with `max` but for minimum temperature
@@ -134,6 +162,7 @@ Example responses - average:
     "data": {
         "ave": 19.64,
         "count": 1173,
+        "unit": "C",
         "from": 0,
         "lower": 1474264875,
         "upper": 1474357264,
@@ -150,6 +179,7 @@ And maximum:
 {
     "data": {
         "count": 1180,
+        "unit": "C",
         "from": 0,
         "lower": 1474264875,
         "max": {

--- a/database.py
+++ b/database.py
@@ -31,6 +31,24 @@ class Temperature(Base):
                 'timestamp': self.timestamp
                 }
 
+class GeneralTemp(object):
+    timestamp = 0
+    temperature = 0
+
+    def __init__(self, temperature, timestamp):
+        self.temperature = temperature
+        self.timestamp = timestamp
+
+    def __repr__(self):
+        return "Temperature {}°C at {}".\
+               format(self.temperature, self.timestamp)
+
+    def dict(self):
+        return {
+                'temperature': self.temperature,
+                'timestamp': self.timestamp
+                }
+
 class db():
     def __init__(self, url):
         """ inits the database """
@@ -43,19 +61,35 @@ class db():
         """ create all the tables and such """
         self.metadata.create_all(self.engine)
 
-    def get_current_temperature(self):
+    def convert_temperature(self, value, unit):
+        if unit == 'K':
+          return value + 273.15
+        elif unit == 'F':
+          return (value * 1.8) + 32
+        else:
+          return value
+
+    def get_current_temperature(self, unit):
         query = self.session.query(Temperature, func.max(Temperature.timestamp))
         t = query.one()
+        curr_temp = GeneralTemp(t[0].temperature, t[0].timestamp)
+        curr_temp.temperature = self.convert_temperature(curr_temp.temperature, unit)
         # note: it's a two tuple - (temperature_object, timestamp)
-        return t[0].dict()
+        return {'current': curr_temp.dict(),
+                'unit': unit,
+        }
 
-    def get_temperature_at(self, timestamp):
+    def get_temperature_at(self, timestamp, unit):
         query = self.session.query(Temperature)
         query = query.order_by(func.abs(Temperature.timestamp - timestamp))
         temp = query.first()
-        return temp.dict()
+        spot_temp = GeneralTemp(temp.temperature, temp.timestamp)
+        spot_temp.temperature = self.convert_temperature(spot_temp.temperature, unit)
+        return {'spot': spot_temp.dict(),
+                'unit': unit,
+        }
 
-    def get_temperature_list(self, lower, upper, limit):
+    def get_temperature_list(self, lower, upper, unit, limit):
         """ returns a list of temperatures within (and including) the lower and
         upper timestamp bounds """
 
@@ -83,7 +117,10 @@ class db():
         #   timestamp of the first record
         #   timestamp of the last record
         results = query.all()
-        temps = list(map(lambda t: t.dict(), results))
+        temperature_data = []
+        for result in results:
+          temperature_data.append(GeneralTemp(self.convert_temperature(result.temperature, unit), result.timestamp))
+        temps = list(map(lambda t: t.dict(), temperature_data))
         return (temps,
                 n,
                 results[0].timestamp if 0 < len(results) else None,
@@ -98,7 +135,7 @@ class db():
         self.session.add(t)
         return self.commit()
 
-    def get_temperature_avg(self, lower, upper):
+    def get_temperature_avg(self, lower, upper, unit):
         query = self.session.query(func.avg(Temperature.temperature), func.count(Temperature.id), func.min(Temperature.timestamp), func.max(Temperature.timestamp))
         filtered = query.filter(Temperature.timestamp >= lower,
                                 Temperature.timestamp <= upper)
@@ -106,21 +143,26 @@ class db():
         t = filtered.first()
         # t is a 4-tuple: (average, number_of_points, smallest timestamp, largest timestamp)
         if t:
-            return {'ave': t[0],
+            return {'ave': self.convert_temperature(t[0], unit) if t[0] else None,
                     'count': t[1],
+                    'unit': unit,
                     'from': lower,
                     'to': upper,
                     'lower': t[2],
                     'upper': t[3]
             }
 
-    def get_temperature_min(self, lower, upper):
+    def get_temperature_min(self, lower, upper, unit):
         query = self.session.query(Temperature, func.count(Temperature.id), func.min(Temperature.temperature))
         filtered = query.filter(Temperature.timestamp >= lower,
                                 Temperature.timestamp <= upper)
 
         t = filtered.first()
         if t:
+            if t[0]:
+                the_min = GeneralTemp(t[0].temperature, t[0].timestamp)
+                the_min.temperature = self.convert_temperature(the_min.temperature, unit)
+
             # do another query to get the min and max timestamp
             # adding it to the first query confuses which actual Temperature record is returned
             tsrange_query = self.session.query(func.min(Temperature.timestamp), func.max(Temperature.timestamp))
@@ -128,21 +170,26 @@ class db():
                                                     Temperature.timestamp <= upper)
             tsrange = filtered_tsrange.first()
 
-            return {'min': t[0].dict() if t[0] else None,
+            return {'min': the_min.dict() if t[0] else None,
                     'count': t[1],
+                    'unit': unit,
                     'from': lower,
                     'to': upper,
                     'lower': tsrange[0],
                     'upper': tsrange[1]
             }
 
-    def get_temperature_max(self, lower, upper):
+    def get_temperature_max(self, lower, upper, unit):
         query = self.session.query(Temperature, func.count(Temperature.id), func.max(Temperature.temperature))
         filtered = query.filter(Temperature.timestamp >= lower,
                                 Temperature.timestamp <= upper)
 
         t = filtered.first()
         if t:
+            if t[0]:
+                the_max = GeneralTemp(t[0].temperature, t[0].timestamp)
+                the_max.temperature = self.convert_temperature(the_max.temperature, unit)
+
             # do another query to get the min and max timestamp
             # adding it to the first query confuses which actual Temperature record is returned
             tsrange_query = self.session.query(func.min(Temperature.timestamp), func.max(Temperature.timestamp))
@@ -150,15 +197,16 @@ class db():
                                                     Temperature.timestamp <= upper)
             tsrange = filtered_tsrange.first()
 
-            return {'max': t[0].dict() if t[0] else None,
+            return {'max': the_max.dict() if t[0] else None,
                     'count': t[1],
+                    'unit': unit,
                     'from': lower,
                     'to': upper,
                     'lower': tsrange[0],
                     'upper': tsrange[1]
             }
 
-    def get_temperature_stats(self, lower, upper):
+    def get_temperature_stats(self, lower, upper, unit):
 
         # get the actual range
         tsrange_query = self.session.query(func.count(Temperature.id),
@@ -172,13 +220,19 @@ class db():
         query = self.session.query(Temperature, func.max(Temperature.temperature))
         filtered = query.filter(Temperature.timestamp >= lower,
                                 Temperature.timestamp <= upper)
-        the_max = filtered.first()[0]
+        db_max = filtered.first()[0]
+        if db_max:
+            the_max = GeneralTemp(db_max.temperature, db_max.timestamp)
+            the_max.temperature = self.convert_temperature(the_max.temperature, unit)
 
         # min
         query = self.session.query(Temperature, func.min(Temperature.temperature))
         filtered = query.filter(Temperature.timestamp >= lower,
                                 Temperature.timestamp <= upper)
-        the_min = filtered.first()[0]
+        db_min = filtered.first()[0]
+        if db_min:
+            the_min = GeneralTemp(db_min.temperature, db_min.timestamp)
+            the_min.temperature = self.convert_temperature(the_min.temperature, unit)
 
         # ave
         query = self.session.query(func.avg(Temperature.temperature))
@@ -187,10 +241,11 @@ class db():
 
         the_ave = filtered.first()[0]
 
-        return {'max': the_max.dict() if the_max else None,
-                'min': the_min.dict() if the_min else None,
-                'ave': the_ave if the_ave else None,
+        return {'max': the_max.dict() if db_max else None,
+                'min': the_min.dict() if db_min else None,
+                'ave': self.convert_temperature(the_ave, unit) if the_ave else None,
                 'count': count,
+                'unit': unit,
                 'from': lower,
                 'to': upper,
                 'lower': real_lower,

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -53,7 +53,7 @@
       </div>
 
       <div class="well well-lg">
-        <div class="big text-center"><span class="current-temperature"></span>°C</div>
+        <div class="big text-center"><span class="current-temperature"></span></div>
         <p class="text-center">
         Current temperature
         </p>
@@ -70,8 +70,20 @@
             Select an upper and lower date/time range to retrieve stats for, and click the <code>Display</code> button
           </p>
 
+          <div class='col-md-2'>
+            <div class="form-group">
+              <div class='input-group' id='units-div'>
+                <span class="input-group-addon">Unit</span>
+                <select id="units-selector" class="form-control" name="units-selector">
+                  <option value="C" selected="">Celsius</option>
+                  <option value="F">Farenheit</option>
+                  <option value="K">Kelvin</option>
+                </select>
+              </div>
+            </div>
+          </div>
           <!-- from https://eonasdan.github.io/bootstrap-datetimepicker/#linked-pickers -->
-          <div class='col-md-5'>
+          <div class='col-md-4'>
             <div class="form-group">
               <div class='input-group date' id='lower-datepicker'>
                 <span class="input-group-addon">From</span>
@@ -82,7 +94,7 @@
               </div>
             </div>
           </div>
-          <div class='col-md-5'>
+          <div class='col-md-4'>
             <div class="form-group">
               <div class='input-group date' id='upper-datepicker'>
                 <span class="input-group-addon">To</span>
@@ -106,7 +118,7 @@
               <h2 class="panel-title">Min</h2>
             </div>
             <div class="panel-body">
-              <p><b><span class="min-temperature"></span>°C</b></p>
+              <p><b><span class="min-temperature"></span></b></p>
               <span class="min-temperature-date"></span>
             </div>
           </div>
@@ -117,7 +129,7 @@
               <h2 class="panel-title">Average</h2>
             </div>
             <div class="panel-body">
-              <p><b><span class="ave-temperature"></span></b>°C</p>
+              <p><b><span class="ave-temperature"></span></b></p>
               over <span class="ave-temperature-count"></span> samples<br />
               from <span class="ave-temperature-date-lower"></span><br />
               to <span class="ave-temperature-date-upper"></span>
@@ -130,7 +142,7 @@
               <h2 class="panel-title">Max</h2>
             </div>
             <div class="panel-body">
-              <p><b><span class="max-temperature"></span></b>°C</p>
+              <p><b><span class="max-temperature"></span></b></p>
               <span class="max-temperature-date"></span>
             </div>
           </div>

--- a/webapp/js/main.js
+++ b/webapp/js/main.js
@@ -59,12 +59,13 @@ Temperature.prototype.getInfo = function() {
   }
 };
 
-Temperature.prototype.getCurrent = function() {
+Temperature.prototype.getCurrent = function(unit) {
   if (this.ready) {
     return $.ajax(this.endpoint + 'current', {
       jsonp: false,
       dataType: 'json',
       method: 'GET',
+      data: {'unit': unit},
       error: this.errorFunc.bind(this)
     });
   } else {
@@ -72,13 +73,13 @@ Temperature.prototype.getCurrent = function() {
   }
 };
 
-Temperature.prototype.getList = function(from, to) {
+Temperature.prototype.getList = function(from, to, unit) {
   if (this.ready) {
     return $.ajax(this.endpoint, {
       jsonp: false,
       dataType: 'json',
       method: 'GET',
-      data: {'from': from, 'to': to},
+      data: {'from': from, 'to': to, 'unit': unit},
       error: this.errorFunc.bind(this)
     });
   } else {
@@ -86,13 +87,13 @@ Temperature.prototype.getList = function(from, to) {
   }
 };
 
-Temperature.prototype.getStat = function(type, from, to) {
+Temperature.prototype.getStat = function(type, from, to, unit) {
   if (this.ready) {
     return $.ajax(this.endpoint + type, {
       jsonp: false,
       dataType: 'json',
       method: 'GET',
-      data: {'from': from, 'to': to},
+      data: {'from': from, 'to': to, 'unit': unit},
       error: this.errorFunc.bind(this)
     });
   } else {
@@ -119,6 +120,12 @@ function showAlert(selector, type, title, msg) {
   $(selector).append($(alert_html));
 }
 
+// utility function to get the selected unit of measure
+function getUnit() {
+  var e = document.getElementById("units-selector");
+  return e.value;
+}
+
 // utility function to grab the upper and lower timestamps from the date pickers
 function getLimits() {
   var limits = {};
@@ -139,7 +146,7 @@ function updateGraph(markers, baselines) {
   var markers = markers || [];
   var baselines = baselines || [];
 
-  t.getList(limit.from, limit.to).done(function(res, statustext) {
+  t.getList(limit.from, limit.to, getUnit()).done(function(res, statustext) {
 
     var data = res.data.temperature_array.map(function(e) {
       return {date: new Date(e.timestamp*1000), value: e.temperature };
@@ -159,11 +166,11 @@ function updateGraph(markers, baselines) {
       x_accessor: 'date',
       y_accessor: 'value',
       x_label: 'Date',
-      y_label: 'Temperature (°C)',
+      y_label: 'Temperature (°' + getUnit() + ')',
       interpolate: d3.curveCatmullRom.alpha(0.5),
       mouseover: function(d, i) {
         d3.select('#chart svg .mg-active-datapoint')
-          .text(d.value.toFixed(1) + '°C at ' + moment(d.date).toLocaleString());
+          .text(d.value.toFixed(1) + '°' + getUnit() + ' at ' + moment(d.date).toLocaleString());
       },
       baselines: baselines,
       markers: markers,
@@ -173,8 +180,8 @@ function updateGraph(markers, baselines) {
 }
 
 function updateCurrent() {
-  t.getCurrent().done(function(res, statustext) {
-    var temp = res.data.temperature.toFixed(1);
+  t.getCurrent(getUnit()).done(function(res, statustext) {
+    var temp = res.data.current.temperature.toFixed(1) + '°' + res.data.unit;
       $('.current-temperature').text(temp);
     });
 }
@@ -182,17 +189,17 @@ function updateCurrent() {
 function updateStats() {
   var limit = getLimits();
 
-  t.getStat('stats', limit.from, limit.to).done(function(res, statustext) {
+  t.getStat('stats', limit.from, limit.to, getUnit()).done(function(res, statustext) {
     var data = res.data;
     if (data.count > 0) {
       removeAlerts('#stats-alert-box');
 
-      $('.max-temperature').text(data.max.temperature.toFixed(1));
+      $('.max-temperature').text(data.max.temperature.toFixed(1) + '°' + data.unit);
       $('.max-temperature-date').text(moment.unix(data.max.timestamp).toLocaleString());
-      $('.min-temperature').text(data.min.temperature.toFixed(1));
+      $('.min-temperature').text(data.min.temperature.toFixed(1) + '°' + data.unit);
       $('.min-temperature-date').text(moment.unix(data.min.timestamp).toLocaleString());
 
-      $('.ave-temperature').text(data.ave.toFixed(1));
+      $('.ave-temperature').text(data.ave.toFixed(1) + '°' + data.unit);
       $('.ave-temperature-count').text(data.count);
       $('.ave-temperature-date-lower').text(moment.unix(data.lower).toLocaleString());
       $('.ave-temperature-date-upper').text(moment.unix(data.upper).toLocaleString());
@@ -203,18 +210,18 @@ function updateStats() {
         markers = [
           {
             'date': new Date(data.max.timestamp*1000),
-            'label': 'max: ' + data.max.temperature.toFixed(1) + '°C'
+            'label': 'max: ' + data.max.temperature.toFixed(1) + '°' + data.unit
           },
           {
             'date': new Date(data.min.timestamp*1000),
-            'label': 'min: ' + data.min.temperature.toFixed(1) + '°C'
+            'label': 'min: ' + data.min.temperature.toFixed(1) + '°' + data.unit
           },
         ];
 
         baselines = [
           {
             'value': data.ave,
-            'label': 'ave: ' + data.ave.toFixed(1) + '°C'
+            'label': 'ave: ' + data.ave.toFixed(1) + '°' + data.unit
           }
         ];
 
@@ -222,7 +229,7 @@ function updateStats() {
           baselines.push(
             {
               'value': 0,
-              'label': '0°C'
+              'label': '0°' + data.unit
             }
           )
         }


### PR DESCRIPTION
The API adds support for "unit" C, F or K in requests, and returns the
temperatures in those units Celcius, Farenheit, Kelvin respectively.
The Web App knows how to drive the enhanced API and has a new dropdown
control to select the units of measure.

I did this while @swalladge was doing other general stuff, so there are merge conflicts. I will look at those later. For now, putting the pull request here so the code can be reviewed.