### PR TITLE
Support selection of Unit of Measure for Temperature

### DIFF
--- a/SERVER_README.md
+++ b/SERVER_README.md
@@ -43,15 +43,22 @@ or on error:
 
 ### GET /api/temperature/current
 
-Returns the current temperature (ie. last recorded temperature in database).
+Returns the current temperature (ie. last recorded temperature in database) and its unit of measure.
+
+Parameters:
+
+- `unit` - C, F, K or R return the result in Celsius, Farenheit, Kelvin or Rankine (default: C)
 
 Example response:
 
 ```json
 {
     "data": {
-        "temperature": 36.3,
-        "timestamp": 1474264875
+        "unit": "C",
+        "current": {
+            "temperature": 36.3,
+            "timestamp": 1474264875
+        },
     },
     "status": 200,
     "success": true
@@ -61,9 +68,27 @@ Example response:
 
 ### GET /api/temperature/:timestamp
 
-Returns the temperature at `timestamp` if available, otherwise temperature for closest available time.
+Returns the spot temperature at `timestamp` if available, otherwise temperature for closest available time, and its unit of measure.
 
-Response follows the same schema as for the current temperature endpoint.
+Parameters:
+
+- `unit` - C, F, K or R return the result in Celsius, Farenheit, Kelvin or Rankine (default: C)
+
+Example response:
+
+```json
+{
+    "data": {
+        "unit": "C",
+        "spot": {
+            "temperature": 36.3,
+            "timestamp": 1474264875
+        },
+    },
+    "status": 200,
+    "success": true
+}
+```
 
 
 ### GET /api/temperature/
@@ -74,12 +99,14 @@ Parameters:
 
 - `from` - [timestamp] start date of temperature range (default: 0)
 - `to` - [timestamp] end date of temperature range (default: current time)
+- `unit` - C, F, K or R return the result in Celsius, Farenheit, Kelvin or Rankine (default: C)
 - `limit` - [integer] limit the number of temperature entries returned (default: `temp_max_length` as configured in
   config.py). Note: a limit parameter higher than set in server config will be ignored.
 
 Response data fields:
 
 - `count`: number of data points returned
+- `unit`: the unit of measure C, F, K or R
 - `lower`: lowest actual timestamp in the data (might be greater than from)
 - `upper`: highest actual timestamp in the data (might be less than to)
 - `from`: the requested start date
@@ -93,6 +120,7 @@ Example response:
     "data": {
         "count": 2,
         "full_count": 2,
+        "unit": "C",
         "from": 1474357000,
         "lower": 1474357004,
         "temperature_array": [
@@ -122,7 +150,7 @@ Parameters as for getting an array of temperatures.
 
 Response data fields:
 
-- `count`, `lower`, `upper`, `from`, `to` as above
+- `count`, `lower`, `upper`, `from`, `to`, `unit` as above
 - `ave`: average temperature as a float number
 - `max`: maximum temperature as a temperature dictionary with `temperature` and `timestamp` fields
 - `min`: as with `max` but for minimum temperature
@@ -134,6 +162,7 @@ Example responses - average:
     "data": {
         "ave": 19.64,
         "count": 1173,
+        "unit": "C",
         "from": 0,
         "lower": 1474264875,
         "upper": 1474357264,
@@ -150,6 +179,7 @@ And maximum:
 {
     "data": {
         "count": 1180,
+        "unit": "C",
         "from": 0,
         "lower": 1474264875,
         "max": {

--- a/app.py
+++ b/app.py
@@ -27,6 +27,7 @@ class temperature_handler(BaseHandler):
 
         from_timestamp = self.get_query_argument('from', None)
         to_timestamp = self.get_query_argument('to', None)
+        unit = self.get_query_argument('unit', 'C')
         limit = self.get_query_argument('limit', cfg.temp_max_length)
 
         try:
@@ -48,7 +49,7 @@ class temperature_handler(BaseHandler):
                 return self.send_error(400, reason='invalid timestamp')
 
             # see if we have a temperature for that time
-            t = self.db.get_temperature_at(timestamp)
+            t = self.db.get_temperature_at(timestamp, unit)
             if t:
                 return self.send_data(t)
             else:
@@ -56,7 +57,7 @@ class temperature_handler(BaseHandler):
 
         # otherwise, use the temperature range
         else:
-            data = self.db.get_temperature_list(from_timestamp, to_timestamp, limit)
+            data = self.db.get_temperature_list(from_timestamp, to_timestamp, unit, limit)
             if data:
                 return self.send_data(data)
 
@@ -68,7 +69,8 @@ class current_temp_handler(BaseHandler):
 
     def get(self):
 
-        t = self.db.get_current_temperature()
+        unit = self.get_query_argument('unit', 'C')
+        t = self.db.get_current_temperature(unit)
         if t:
             return self.send_data(t)
         else:
@@ -83,6 +85,7 @@ class stats_temp_handler(BaseHandler):
 
         from_timestamp = self.get_query_argument('from', None)
         to_timestamp = self.get_query_argument('to', None)
+        unit = self.get_query_argument('unit', 'C')
 
         try:
             from_timestamp, to_timestamp = utils.validate_bounds(from_timestamp, to_timestamp)
@@ -90,16 +93,16 @@ class stats_temp_handler(BaseHandler):
             return self.send_error(400, reason='invalid range (from-to)')
 
         if stats_type == 'min':
-            stats = self.db.get_temperature_min(from_timestamp, to_timestamp)
+            stats = self.db.get_temperature_min(from_timestamp, to_timestamp, unit)
             if stats: return self.send_data(stats)
         elif stats_type == 'max':
-            stats = self.db.get_temperature_max(from_timestamp, to_timestamp)
+            stats = self.db.get_temperature_max(from_timestamp, to_timestamp, unit)
             if stats: return self.send_data(stats)
         elif stats_type == 'ave':
-            ave = self.db.get_temperature_avg(from_timestamp, to_timestamp)
+            ave = self.db.get_temperature_avg(from_timestamp, to_timestamp, unit)
             if ave: return self.send_data(ave)
         elif stats_type == 'stats':
-            stats = self.db.get_temperature_stats(from_timestamp, to_timestamp)
+            stats = self.db.get_temperature_stats(from_timestamp, to_timestamp, unit)
             if stats: return self.send_data(stats)
 
         return self.send_error(500, reason='error retrieving {}'.format(stats_type))

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -62,7 +62,7 @@
       </div>
 
       <div class="well">
-        <div class="big text-center"><span class="current-temperature"></span>°C</div>
+        <div class="big text-center"><span class="current-temperature"></span></div>
         <p class="text-center">
         Current temperature
         </p>
@@ -80,8 +80,21 @@
               Select an upper and lower date-time range to retrieve data for, and click <code>Display</code>.
             </p>
 
+            <div class='col-md-2'>
+              <div class="form-group">
+                <div class='input-group' id='units-div'>
+                  <span class="input-group-addon">Unit</span>
+                  <select id="units-selector" class="form-control" name="units-selector">
+                    <option value="C" selected="">Celsius</option>
+                    <option value="F">Farenheit</option>
+                    <option value="K">Kelvin</option>
+                    <option value="R">Rankine</option>
+                  </select>
+                </div>
+              </div>
+            </div>
             <!-- from https://eonasdan.github.io/bootstrap-datetimepicker/#linked-pickers -->
-            <div class='col-md-5'>
+            <div class='col-md-4'>
               <div class="form-group">
                 <div class='input-group date' id='lower-datepicker'>
                   <span class="input-group-addon">From</span>
@@ -92,7 +105,7 @@
                 </div>
               </div>
             </div>
-            <div class='col-md-5'>
+            <div class='col-md-4'>
               <div class="form-group">
                 <div class='input-group date' id='upper-datepicker'>
                   <span class="input-group-addon">To</span>
@@ -117,7 +130,7 @@
               <h2 class="panel-title">Min</h2>
             </div>
             <div class="panel-body">
-              <p><b><span class="min-temperature"></span>°C</b></p>
+              <p><b><span class="min-temperature"></span></b></p>
               <span class="min-temperature-date"></span>
             </div>
           </div>
@@ -128,7 +141,7 @@
               <h2 class="panel-title">Average</h2>
             </div>
             <div class="panel-body">
-              <p><b><span class="ave-temperature"></span></b>°C</p>
+              <p><b><span class="ave-temperature"></span></b></p>
               over <span class="ave-temperature-count"></span> samples<br />
               from <span class="ave-temperature-date-lower"></span><br />
               to <span class="ave-temperature-date-upper"></span>
@@ -141,7 +154,7 @@
               <h2 class="panel-title">Max</h2>
             </div>
             <div class="panel-body">
-              <p><b><span class="max-temperature"></span></b>°C</p>
+              <p><b><span class="max-temperature"></span></b></p>
               <span class="max-temperature-date"></span>
             </div>
           </div>

--- a/webapp/js/main.js
+++ b/webapp/js/main.js
@@ -60,12 +60,13 @@ Temperature.prototype.getInfo = function() {
   }
 };
 
-Temperature.prototype.getCurrent = function() {
+Temperature.prototype.getCurrent = function(unit) {
   if (this.ready) {
     return $.ajax(this.endpoint + 'current', {
       jsonp: false,
       dataType: 'json',
       method: 'GET',
+      data: {'unit': unit},
       error: this.errorFunc.bind(this)
     });
   } else {
@@ -73,13 +74,13 @@ Temperature.prototype.getCurrent = function() {
   }
 };
 
-Temperature.prototype.getList = function(from, to) {
+Temperature.prototype.getList = function(from, to, unit) {
   if (this.ready) {
     return $.ajax(this.endpoint, {
       jsonp: false,
       dataType: 'json',
       method: 'GET',
-      data: {'from': from, 'to': to},
+      data: {'from': from, 'to': to, 'unit': unit},
       error: this.errorFunc.bind(this)
     });
   } else {
@@ -87,13 +88,13 @@ Temperature.prototype.getList = function(from, to) {
   }
 };
 
-Temperature.prototype.getStat = function(type, from, to) {
+Temperature.prototype.getStat = function(type, from, to, unit) {
   if (this.ready) {
     return $.ajax(this.endpoint + type, {
       jsonp: false,
       dataType: 'json',
       method: 'GET',
-      data: {'from': from, 'to': to},
+      data: {'from': from, 'to': to, 'unit': unit},
       error: this.errorFunc.bind(this)
     });
   } else {
@@ -120,6 +121,12 @@ function showAlert(selector, type, title, msg) {
   $(selector).append($(alert_html));
 }
 
+// utility function to get the selected unit of measure
+function getUnit() {
+  var e = document.getElementById("units-selector");
+  return e.value;
+}
+
 // utility function to grab the upper and lower timestamps from the date pickers
 function getLimits() {
   var limits = {};
@@ -140,7 +147,7 @@ function updateGraph(markers, baselines) {
   var markers = markers || [];
   var baselines = baselines || [];
 
-  t.getList(limit.from, limit.to).done(function(res, statustext) {
+  t.getList(limit.from, limit.to, getUnit()).done(function(res, statustext) {
 
     var data = res.data.temperature_array.map(function(e) {
       return {date: new Date(e.timestamp*1000), value: e.temperature };
@@ -160,11 +167,11 @@ function updateGraph(markers, baselines) {
       x_accessor: 'date',
       y_accessor: 'value',
       x_label: 'Date',
-      y_label: 'Temperature (°C)',
+      y_label: 'Temperature (°' + res.data.unit + ')',
       interpolate: d3.curveCatmullRom.alpha(0.5),
       mouseover: function(d, i) {
         d3.select('#chart svg .mg-active-datapoint')
-          .text(d.value.toFixed(1) + '°C at ' + moment(d.date).format(dateFormat));
+          .text(d.value.toFixed(1) + '°' + res.data.unit + ' at ' + moment(d.date).format(dateFormat));
       },
       baselines: baselines,
       markers: markers,
@@ -174,8 +181,8 @@ function updateGraph(markers, baselines) {
 }
 
 function updateCurrent() {
-  t.getCurrent().done(function(res, statustext) {
-    var temp = res.data.temperature.toFixed(1);
+  t.getCurrent(getUnit()).done(function(res, statustext) {
+    var temp = res.data.current.temperature.toFixed(1) + '°' + res.data.unit;
       $('.current-temperature').text(temp);
     });
 }
@@ -183,17 +190,17 @@ function updateCurrent() {
 function updateStats() {
   var limit = getLimits();
 
-  t.getStat('stats', limit.from, limit.to).done(function(res, statustext) {
+  t.getStat('stats', limit.from, limit.to, getUnit()).done(function(res, statustext) {
     var data = res.data;
     if (data.count > 0) {
       removeAlerts('#stats-alert-box');
 
-      $('.max-temperature').text(data.max.temperature.toFixed(1));
+      $('.max-temperature').text(data.max.temperature.toFixed(1) + '°' + data.unit);
       $('.max-temperature-date').text(moment.unix(data.max.timestamp).format(dateFormat));
-      $('.min-temperature').text(data.min.temperature.toFixed(1));
+      $('.min-temperature').text(data.min.temperature.toFixed(1) + '°' + data.unit);
       $('.min-temperature-date').text(moment.unix(data.min.timestamp).format(dateFormat));
 
-      $('.ave-temperature').text(data.ave.toFixed(1));
+      $('.ave-temperature').text(data.ave.toFixed(1) + '°' + data.unit);
       $('.ave-temperature-count').text(data.count);
       $('.ave-temperature-date-lower').text(moment.unix(data.lower).format(dateFormat));
       $('.ave-temperature-date-upper').text(moment.unix(data.upper).format(dateFormat));
@@ -204,18 +211,18 @@ function updateStats() {
         markers = [
           {
             'date': new Date(data.max.timestamp*1000),
-            'label': 'max: ' + data.max.temperature.toFixed(1) + '°C'
+            'label': 'max: ' + data.max.temperature.toFixed(1) + '°' + data.unit
           },
           {
             'date': new Date(data.min.timestamp*1000),
-            'label': 'min: ' + data.min.temperature.toFixed(1) + '°C'
+            'label': 'min: ' + data.min.temperature.toFixed(1) + '°' + data.unit
           },
         ];
 
         baselines = [
           {
             'value': data.ave,
-            'label': 'ave: ' + data.ave.toFixed(1) + '°C'
+            'label': 'ave: ' + data.ave.toFixed(1) + '°' + data.unit
           }
         ];
 
@@ -223,7 +230,7 @@ function updateStats() {
           baselines.push(
             {
               'value': 0,
-              'label': '0°C'
+              'label': '0°' + data.unit
             }
           )
         }


### PR DESCRIPTION
API enhanced to allow unit parameter in each query endpoint.
Results are returned with all temperatures converted to the requested
unit of measure.
The web app UI allows the user to choose the unit of measure, then
displays the selected unit of measure everywhere when
displaying/graphing the temperature.
Supports 4 temperature scales:
C - Celsius
F - Farenheit
K - Kelvin
R - Rankine (based off Farenheit but starting from absolute zero)