### PR TITLE
Limit decimal places in converted results

### DIFF
--- a/server/database.py
+++ b/server/database.py
@@ -20,13 +20,14 @@ class Temperature(Base):
     @staticmethod
     def convert(t, unit='C'):
         if unit == 'K':
-          return t + 273.15
+          result = t + 273.15
         elif unit == 'F':
-          return (t * 1.8) + 32
+          result = (t * 1.8) + 32
         elif unit == 'R':
-          return (t + 273.15) * 1.8
+          result = (t + 273.15) * 1.8
         else:
-          return t
+          result = t
+        return round(result, 6)
 
     def get_data(self, unit='C'):
         return {


### PR DESCRIPTION
Because:
1) The original temperature samples are only accurate to a few decimals.
2) We don't want to give the impression that figures are super-accurate
3) For testing it is nice to have values returned by the API that do not
have little floating point conversion artifacts like 25.875000001
degrees. If we round such values then we will get stuff like 25.875 and
all implementations (with 32-bit, 64-bit or... floats) will give the
same rounded value.