### PR TITLE
Tests for limit parameter

### DIFF
--- a/server/database.py
+++ b/server/database.py
@@ -92,11 +92,21 @@ class db():
 
         # check if the number of rows returned will be too long
         if n > limit:
-            # if so, skip every jump_th row
-            jump = (n // limit) + 1
             first_id = query.first().id
-            last_id = first_id + n - 1
-            query = query.filter(((Temperature.id - first_id) % jump == 0) | (Temperature.id == last_id))
+            if limit == 1:
+              # They just want only 1 point, so choose a point near the middle
+              middle_id = first_id + (n // 2)
+              query = query.filter(Temperature.id == middle_id)
+            else:
+              # Choose up to (limit-1) rows from the first (n-1) rows
+              # by selecting every jump_th row
+              jump = ((n-1) // (limit-1)) + 1
+              # Organise the mod (%) calculation to always select the first row
+              # by calculating the offset of the id from the first_id
+              # And always select the last row,
+              # which could make at most((limit-1)+1)=limit rows in total
+              last_id = first_id + n - 1
+              query = query.filter(((Temperature.id - first_id) % jump == 0) | (Temperature.id == last_id))
 
         results = query.all()
         temps = list(map(lambda t: t.get_data(unit), results))

--- a/tests/api_temperature_array_tests_spec.js
+++ b/tests/api_temperature_array_tests_spec.js
@@ -534,3 +534,166 @@ frisby.create('Temperature array from greater than to test')
   })
 .toss();
 
+// Get an array of temperatures with invalid limit
+frisby.create('Temperature array invalid limit 0 test')
+  .get('http://localhost:8888/api/temperature?limit=0')
+  .expectStatus(400)
+  .expectHeaderContains('content-type', 'application/json')
+  .expectJSON({
+    success: false,
+    reason: "invalid parameters ('from', 'to', or 'limit' was invalid)"
+  })
+.toss();
+
+// Get an array of temperatures with invalid limit
+frisby.create('Temperature array invalid limit 0.5 test')
+  .get('http://localhost:8888/api/temperature?limit=0.5')
+  .expectStatus(400)
+  .expectHeaderContains('content-type', 'application/json')
+  .expectJSON({
+    success: false,
+    reason: "invalid parameters ('from', 'to', or 'limit' was invalid)"
+  })
+.toss();
+
+// Get an array of temperatures with invalid limit
+frisby.create('Temperature array invalid limit -1 test')
+  .get('http://localhost:8888/api/temperature?limit=-1')
+  .expectStatus(400)
+  .expectHeaderContains('content-type', 'application/json')
+  .expectJSON({
+    success: false,
+    reason: "invalid parameters ('from', 'to', or 'limit' was invalid)"
+  })
+.toss();
+
+// Get an array of temperatures with invalid limit
+frisby.create('Temperature array invalid limit a test')
+  .get('http://localhost:8888/api/temperature?limit=a')
+  .expectStatus(400)
+  .expectHeaderContains('content-type', 'application/json')
+  .expectJSON({
+    success: false,
+    reason: "invalid parameters ('from', 'to', or 'limit' was invalid)"
+  })
+.toss();
+
+// Get an array of temperatures with limit 1 (returns just the middle point)
+frisby.create('Temperature array limit 1 test')
+  .get('http://localhost:8888/api/temperature?limit=1')
+  .expectStatus(200)
+  .expectHeaderContains('content-type', 'application/json')
+  .expectJSON({
+    success: true,
+    data: {
+      count: 1,
+      full_count: 50,
+      from: 0,
+      lower: 1451612500,
+      upper: 1451612500,
+      unit: "C",
+      temperature_array: [
+        {
+          temperature: 12.3,
+          timestamp: 1451612500
+        }
+	  ]
+    }
+  })
+  .expectJSONTypes({
+    data: {
+      count: Number,
+      full_count: Number,
+      from: Number,
+      to: Number,
+      lower: Number,
+      upper: Number,
+      unit: String,
+      temperature_array: Array
+    }
+  })
+.toss();
+
+// Get an array of temperatures with limit 2 (returns just the start and end point)
+frisby.create('Temperature array limit 2 test')
+  .get('http://localhost:8888/api/temperature?limit=2')
+  .expectStatus(200)
+  .expectHeaderContains('content-type', 'application/json')
+  .expectJSON({
+    success: true,
+    data: {
+      count: 2,
+      full_count: 50,
+      from: 0,
+      lower: 1451610000,
+      upper: 1451614900,
+      unit: "C",
+      temperature_array: [
+        {
+          temperature: 10.0,
+          timestamp: 1451610000
+        },
+        {
+          temperature: 8.4,
+          timestamp: 1451614900
+        }
+	  ]
+    }
+  })
+  .expectJSONTypes({
+    data: {
+      count: Number,
+      full_count: Number,
+      from: Number,
+      to: Number,
+      lower: Number,
+      upper: Number,
+      unit: String,
+      temperature_array: Array
+    }
+  })
+.toss();
+
+// Get an array of temperatures with limit 3 (returns the start, middle and end point)
+frisby.create('Temperature array limit 3 test')
+  .get('http://localhost:8888/api/temperature?limit=3')
+  .expectStatus(200)
+  .expectHeaderContains('content-type', 'application/json')
+  .expectJSON({
+    success: true,
+    data: {
+      count: 3,
+      full_count: 50,
+      from: 0,
+      lower: 1451610000,
+      upper: 1451614900,
+      unit: "C",
+      temperature_array: [
+        {
+          temperature: 10.0,
+          timestamp: 1451610000
+        },
+        {
+          temperature: 12.3,
+          timestamp: 1451612500
+        },
+        {
+          temperature: 8.4,
+          timestamp: 1451614900
+        }
+	  ]
+    }
+  })
+  .expectJSONTypes({
+    data: {
+      count: Number,
+      full_count: Number,
+      from: Number,
+      to: Number,
+      lower: Number,
+      upper: Number,
+      unit: String,
+      temperature_array: Array
+    }
+  })
+.toss();


### PR DESCRIPTION
Enhance the code that calculates the jump factor to:
a) If limit = 1 then this is a special case where we return the middle sample of the range.
b) Calculate up to (limit-1) points from the first (n-1) points, then always include the last point, making a maximum of up to limit points.
Previously it would sometimes return limit+1 points (e.g. in live data with a limit of 300, it sometimes returned 301 points, and with various limits out of the 50-point test data, it would return limit+1 points).
I will add a few more test cases later tonight.