### PR TITLE
Allow generating large amounts of test data

### DIFF
--- a/tests/acceptance_test_data.txt
+++ b/tests/acceptance_test_data.txt
@@ -1,0 +1,6 @@
+# Acceptance Test time and temperature data
+# Generate a year of pseudo-random temperature records
+# starting from 2016-07-01 (which is Unix timestamp 1435708800)
+# at 5-minute intervals (300 seconds)
+# for 12 records/hour * 24 hours/day * 365 days/year = 105120 records/year
+generate 1435708800 300 105120

--- a/tests/config.acceptance_test.json
+++ b/tests/config.acceptance_test.json
@@ -1,0 +1,15 @@
+{
+        "database_url": "sqlite:///db.sqlite3",
+        "cors_origin": "*",
+        "listen_port": 8888,
+        "debug_mode": true,
+        "serve_webapp": true,
+        "on_rpi": false,
+        "test_data": "tests/acceptance_test_data.txt",
+        "sensor_params": null,
+        "temp_interval": 5,
+        "temp_max_length": 300,
+        "server_name": "Acceptance Test Temperature Server",
+        "location": "",
+        "timezone": 570
+}


### PR DESCRIPTION
So that acceptance tests can be run on real hardware with a realistic
amount of data to check performance.

A test data file can have line(s) like:
generate start_timestamp interval_secs count

- start from the given Unix timestamp
- generate a temperature record each interval_secs
- generate count number of records

e.g.
generate 1435708800 300 105120

will generate 105120 records at 5 minute (300 second) intervals, which
makes about 1 year of data.